### PR TITLE
Support proper include paths for compiled app

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ that can be put in a consult file can be put in `{proper_opts, [Options]}.` in y
 Changelog
 ----
 
+Pending release:
+- fix bug with include paths of hrl files from parent apps
+
 - 0.6.3: fix bug with cover-compiling in rebar 3.2.0 and above again
 - 0.6.2: fix bug with cover-compiling in rebar 3.2.0 and above
 - 0.6.1: fix bug on option parsing in config files

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -191,7 +191,7 @@ add_includes(NewOpts, State) ->
 app_includes(App) ->
     Opts = rebar_app_info:opts(App),
     Dir = rebar_app_info:dir(App),
-    [{i, filename:join(Dir, Src)} || Src <- rebar_dir:src_dirs(Opts, ["src"])]
+    [{i, filename:join(Dir, Src)} || Src <- rebar_dir:all_src_dirs(Opts, ["src"], [])]
     ++
     [{i, filename:join(Dir, "include")},
      {i, Dir}]. % not sure for that one, but mimics the rebar3_erlc_compiler


### PR DESCRIPTION
This adds support for common rebar3-supported include path in test data
for all their related test cases.

This _should_ work similarly to how eunit and CT provider works (all
tests see all include files of all top-level apps, private or not),
although full functionality for private include files still relies on a
rebar3 fix.

Full details at https://github.com/ferd/rebar3_proper/issues/8
