### PR TITLE
Using set path fixes weird priv_dir issues.

### DIFF
--- a/src/rebar3_proper.app.src
+++ b/src/rebar3_proper.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_proper,
  [{description, "Run PropEr test suites"},
-  {vsn, "0.7.0"},
+  {vsn, "0.7.1"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -41,7 +41,8 @@ do(State) ->
     %% code path but not pre-loaded in memory, though.
     TopAppsPaths = app_paths(State),
     rebar_utils:update_code(rebar_state:code_paths(State, all_deps)--TopAppsPaths, [soft_purge]),
-    code:add_patha(TopAppsPaths),
+    FlatPaths = TopAppsPaths ++ (code:get_path() -- TopAppsPaths),
+    true = code:set_path(FlatPaths),
     case run_type(Opts) of
         quickcheck -> do_quickcheck(State, Opts, ProperOpts);
         retry -> do_retry(State, Opts, ProperOpts)


### PR DESCRIPTION
I'm not 100% sure how, but it seems that using `set_path` instead of
just `add_path` changes how libraries are looked into by the Erlang VM
when it comes to priv dirs and lib dirs.

This commit forces the addition of apps' paths through this function
rather than just adding the paths, which appears to fix some subtle bugs
in umbrella apps with private tests requiring access to priv and lib
dirs for the app they're part of.

Should fix https://github.com/ferd/rebar3_proper/issues/12

@pulltab if you could please try this branch with your code to confirm
that the fix works for your environment too, this would be good.

Change the plugin line to:
` { rebar3_proper, {git, "https://github.com/ferd/rebar3_proper.git", {branch, "fix-app-paths"}}},`

Then kill the `_build/*/plugins` directory (if you don't want to blow `_build` away altogether)

It works for me on your project after this, and keeps working on other projects too.
If that's fixed, I'll cut and release to hex.