### PR TITLE
Introduce Regressions Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ directories of a rebar3 project, and running all properties (functions of arity
 Todo/Gotchas
 ----
 
-- No automated tests yet
-- would like to find a way to store failed tests to a counterexample file
-  that can be re-run at will rather than just using `--retry` on the
-  latest failing case.
+- No automated tests yet since this repo runs tests for a living
 
 Use
 ---
@@ -33,7 +30,8 @@ Then just call your plugin directly in an existing application:
 
     Usage: rebar3 proper [-d <dir>] [-m <module>] [-p <properties>]
                          [-n <numtests>] [-v <verbose>] [-c [<cover>]]
-                         [--long_result <long_result>]
+                         [--retry [<retry>]] [--regressions [<regressions>]]
+                         [--store [<store>]] [--long_result <long_result>]
                          [--start_size <start_size>] [--max_size <max_size>]
                          [--max_shrinks <max_shrinks>]
                          [--noshrink <noshrink>]
@@ -52,6 +50,10 @@ Then just call your plugin directly in an existing application:
       -c, --cover         generate cover data [default: false]
       --retry             If failing test case counterexamples have been
                           stored, they are retried [default: false]
+      --regressions       replays the test cases stored in the regression
+                          file. [default: false]
+      --store             stores the last counterexample into the regression
+                          file. [default: false]
       --long_result       enables long-result mode, displaying
                           counter-examples on failure rather than just false
       --start_size        specifies the initial value of the size parameter
@@ -71,10 +73,20 @@ Then just call your plugin directly in an existing application:
 All of [PropEr's standard configurations](http://proper.softlab.ntua.gr/doc/proper.html#Options)
 that can be put in a consult file can be put in `{proper_opts, [Options]}.` in your rebar.config file.
 
+Workflow
+---
+
+A workflow to handle errors and do development is being experimented with:
+
+1. Run any properties with `rebar3 proper`
+2. On a test failure, replay the last failing cases with `rebar3 proper --retry`
+3. Call `rebar3 proper --store` if the cases are interesting and you want to keep them for the future. The entries will be appended in a `proper-regressions.consult` file in your configured test directory. Check in that file or edit it as you wish.
+4. Use `rebar3 proper --regressions` to prevent regressions from happening by testing your code against all stored counterexamples
 
 Changelog
 ----
 
+- 0.8.0: storage and replay of counterexamples
 - 0.7.2: rely on a non-beta PropEr version
 - 0.7.1: fix bug regarding lib and priv directories in code path
 - 0.7.0: fix bug with include paths of hrl files from parent apps, support counterexamples with --retry

--- a/src/rebar3_proper.app.src
+++ b/src/rebar3_proper.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_proper,
  [{description, "Run PropEr test suites"},
-  {vsn, "0.7.2"},
+  {vsn, "0.8.0"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
1. Run any properties with `rebar3 proper`
2. On a test failure, replay the last failing cases with `rebar3 proper --retry`
3. Call `rebar3 proper --store` if the cases are interesting and you want to keep them for the future. The entries will be appended in a `proper-regressions.consult` file in your configured test directory. Check in that file to source control and edit it as you wish.
4. Use `rebar3 proper --regressions` to prevent regressions from happening by testing your code against all stored counterexamples