### PR TITLE
Fix unused mytype generator in erl template

### DIFF
--- a/priv/templates/prop.erl.tpl
+++ b/priv/templates/prop.erl.tpl
@@ -5,7 +5,7 @@
 %%% Properties %%%
 %%%%%%%%%%%%%%%%%%
 prop_test() ->
-    ?FORALL(Type, term(),
+    ?FORALL(Type, mytype(),
         begin
             boolean(Type)
         end).


### PR DESCRIPTION
Gets rid of the `function mytype/0 is unused` warning and aligns with https://propertesting.com/book_stateless_properties.html