### PR TITLE
Remove call to deprecated compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The meta function may be omitted entirely.
 Changelog
 ----
 
+- 0.12.0: drop compile phase since newer rebar3 versions handle all of that for us out of the box. Eliminates old deprecation warning.
 - 0.11.1: fix unicode support in meta-functions output
 - 0.11.0: add option to set search steps for targeted properties
 - 0.10.4: add PropEr FSM template

--- a/src/rebar3_proper.app.src
+++ b/src/rebar3_proper.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_proper,
  [{description, "Run PropEr test suites"},
-  {vsn, "0.11.1"},
+  {vsn, "0.12.0"},
   {registered, []},
   {applications,
    [kernel,
@@ -10,7 +10,6 @@
   {env,[]},
   {modules, []},
 
-  {maintainers, ["Fred Hebert"]},
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/ferd/rebar3_proper"},
            {"PropEr", "http://proper.softlab.ntua.gr/"}]}

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -300,7 +300,6 @@ find_properties(State, Dir, Mods, Props) ->
             || {App, TestDir} <- TestDirs,
                {ok, Files} <- [file:list_dir(TestDir)],
                lists:any(fun(File) -> prop_suite(Mods, File) end, Files)],
-    compile_dirs(State, Dir, Dirs),
     [Prop || {_, TestDir} <- Dirs,
              {ok, Files} <- [file:list_dir(TestDir)],
              File <- Files,
@@ -326,49 +325,6 @@ properties(Props, Mod) ->
 
 prop_prefix(Atom) ->
     lists:prefix("prop_", atom_to_list(Atom)).
-
-compile_dirs(State, _TestDir, Dirs) -> % [{App, Dir}]
-    %% Set up directory -- may need to unlink then re-link
-    %% copy contents into directory
-    %% call the compiler
-    [begin
-       rebar_api:debug("Compiling ~s for PropEr", [AppName]),
-       setup(State, OutDir),
-       compile(State, AppName, Dir, OutDir)
-     end || {{AppName, OutDir}, Dir} <- Dirs],
-    rebar_api:debug("App compiled", []).
-
-setup(_State, OutDir) ->
-    filelib:ensure_dir(filename:join([OutDir, "dummy.beam"])).
-
-compile(State, AppName, Src, Out) ->
-    Opts = case AppName of
-        <<"root">> -> rebar_state:opts(State);
-        _ -> rebar_app_info:opts(find_app(AppName, State))
-    end,
-    rebar_api:debug("Compiling files in ~s to ~s", [Src, Out]),
-    NewOpts = lists:foldl(fun({K, V}, Dict) -> rebar_opts:set(Dict, K, V) end,
-                          Opts,
-                          [{src_dirs, ["."]}]),
-    IncludeOpts = add_includes(NewOpts, State),
-    rebar_erlc_compiler:compile(IncludeOpts, Src, ec_cnv:to_list(Out)).
-
-find_app(AppName, State) ->
-    [App] = [App || App <- rebar_state:project_apps(State),
-                    rebar_app_info:name(App) =:= AppName],
-    App.
-
-add_includes(NewOpts, State) ->
-    Includes = lists:flatmap(fun app_includes/1, rebar_state:project_apps(State)),
-    dict:append_list(erl_opts, Includes, NewOpts).
-
-app_includes(App) ->
-    Opts = rebar_app_info:opts(App),
-    Dir = rebar_app_info:dir(App),
-    [{i, filename:join(Dir, Src)} || Src <- rebar_dir:all_src_dirs(Opts, ["src"], [])]
-    ++
-    [{i, filename:join(Dir, "include")},
-     {i, Dir}]. % not sure for that one, but mimics the rebar3_erlc_compiler
 
 proper_opts() ->
     [{dir, $d, "dir", string,


### PR DESCRIPTION
The new compiler modules remove all need for these to even be called in
the first place; depending on the `compile task` automatically sorts out
the compilation that this plugin requires.

This was likely a leftover of prior execution modes where we didn't
expect users to actually depend on PropEr and the modules wouldn't
compile on their own.