### PR TITLE
Add parallel PropEr options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then just call your plugin directly in an existing application:
 
     Usage: rebar3 proper [-d <dir>] [-m <module>] [-p <properties>]
                          [-n <numtests>] [-v <verbose>] [-c [<cover>]]
+                         [-w <workers>] [-t <property_type>]
                          [--retry [<retry>]] [--regressions [<regressions>]]
                          [--store [<store>]] [--long_result <long_result>]
                          [--start_size <start_size>] [--max_size <max_size>]
@@ -45,6 +46,7 @@ Then just call your plugin directly in an existing application:
                          [--constraint_tries <constraint_tries>]
                          [--spec_timeout <spec_timeout>]
                          [--any_to_integer <any_to_integer>]
+                         [--stop_nodes <boolean>]
     
       -d, --dir           directory where the property tests are located
                           (defaults to "test"). The directory also needs to be
@@ -58,6 +60,12 @@ Then just call your plugin directly in an existing application:
       -v, --verbose       each propertie tested shows its output or not
                           (defaults to true)
       -c, --cover         generate cover data [default: false]
+      -w, --workers       number of workers to use when parallelizing property 
+                          tests
+      -t, --type          this is only used when running parallel PropEr: 
+                          indicates the type of the property to test, it can 
+                          either be "pure" when it is side-effect and has no 
+                          state, or "impure" when it does
       --retry             If failing test case counterexamples have been
                           stored, they are retried [default: false]
       --regressions       replays the test cases stored in the regression
@@ -79,6 +87,10 @@ Then just call your plugin directly in an existing application:
                           considers an input to be failing
       --any_to_integer    converts instances of the any() type to integers in
                           order to speed up execution
+      --stop_nodes        this is only used when running parallel PropEr: 
+                          indicates whether PropEr should restart the nodes 
+                          for each impure property, when testing them in 
+                          parallel, or not
 
 All of [PropEr's standard configurations](http://proper.softlab.ntua.gr/doc/proper.html#Options)
 that can be put in a consult file can be put in `{proper_opts, [Options]}.` in your rebar.config file.

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -356,6 +356,8 @@ proper_opts() ->
       "each property tested shows its output or not (defaults to true)"},
      {cover, $c, "cover", {boolean, false},
       "generate cover data"},
+     {numworkers, $w, "workers", integer,
+      "number of workers to use when parallelizing property tests"},
      %% no short format for these buddies
      {retry, undefined, "retry", {boolean, false},
       "If failing test case counterexamples have been stored, "

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -358,6 +358,10 @@ proper_opts() ->
       "generate cover data"},
      {numworkers, $w, "workers", integer,
       "number of workers to use when parallelizing property tests"},
+     {type, $t, "type", atom,
+      "this is only used when running parallel PropEr: indicates the "
+      "type of the property to test, it can either be \"pure\" when it is side-effect "
+      "and has no state, or \"impure\" when it does"},
      %% no short format for these buddies
      {retry, undefined, "retry", {boolean, false},
       "If failing test case counterexamples have been stored, "
@@ -442,6 +446,7 @@ proper_opts([{on_output, MFStr} | T]) when is_list(MFStr) ->
         undefined -> proper_opts(T);
         Fun       -> [{on_output, Fun} | proper_opts(T)]
     end;
+proper_opts([{type, Type} | T]) -> [Type | proper_opts(T)];
 %% those are rebar3-only options
 proper_opts([{dir,_} | T]) -> proper_opts(T);
 proper_opts([{module,_} | T]) -> proper_opts(T);

--- a/src/rebar3_proper_prv.erl
+++ b/src/rebar3_proper_prv.erl
@@ -396,7 +396,11 @@ proper_opts() ->
       "specifies a binary function '{Mod,Fun}', similar to io:format/2, "
       "to be used for all output printing"},
      {sys_config, undefined, "sys_config", string,
-      "config file to load before starting tests"}
+      "config file to load before starting tests"},
+     {stop_nodes, undefined, "stop_nodes", boolean,
+      "this is only used when running parallel PropEr: indicates whether "
+      "PropEr should restart the nodes for each impure property, "
+      "when testing them in parallel, or not"}
     ].
 
 handle_opts(State) ->


### PR DESCRIPTION
Since the work on parallelizing PropEr has been merged and is included in the latest release, I thought it would be nice to include some helper options in this plugin to ease testing with the new features.

This PR in short adds the following options:
- `[-w, --workers]`, to set how many workers the tool has to use when testing each property in parallel
- `[-t, --type]`, to set the type of the property that is going to be tested
- `--stop_nodes`, to avoid restarting the nodes (just in the case of impure tests) for each property that is going to be tested 