### PR TITLE
update the PropEr web link

### DIFF
--- a/src/rebar3_proper.app.src
+++ b/src/rebar3_proper.app.src
@@ -12,5 +12,5 @@
 
   {licenses, ["BSD"]},
   {links, [{"Github", "https://github.com/ferd/rebar3_proper"},
-           {"PropEr", "http://proper.softlab.ntua.gr/"}]}
+           {"PropEr", "https://proper-testing.github.io/"}]}
  ]}.


### PR DESCRIPTION
The PropEr project web site seems to have moved to github, and is more up to date :-)